### PR TITLE
UID2-6916: Fix CVE-2026-33870 and CVE-2026-33871 - Force netty to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,29 @@
         <java.version>21</java.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force netty to 4.1.132.Final to fix CVE-2026-33870 and CVE-2026-33871 (UID2-6916) -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>4.1.132.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>4.1.132.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.132.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.uid2</groupId>


### PR DESCRIPTION
## Summary

Fixes two HIGH-severity netty vulnerabilities detected by Trivy vulnerability scan:

- **CVE-2026-33870** (HIGH): `io.netty:netty-codec-http` - Request smuggling vulnerability. Fixed in 4.1.132.Final.
- **CVE-2026-33871** (HIGH): `io.netty:netty-codec-http2` - Denial of Service via HTTP/2 CONTINUATION flood. Fixed in 4.1.132.Final.

Both CVEs are transitive dependencies brought in by the Azure SDK. This PR adds a `dependencyManagement` section to force `io.netty` packages to `4.1.132.Final`.

## Jira

[UID2-6916](https://thetradedesk.atlassian.net/browse/UID2-6916)

## Test plan

- [ ] Trivy vulnerability scan passes with no HIGH/CRITICAL findings
- [ ] All existing unit tests pass