### PR TITLE
UID2-7027: Upgrade netty 4.1.132 → 4.1.133 (3 HIGH CVEs)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,14 @@
 # List any vulnerability that are to be accepted
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/
 # for more details
+
+# CVE-2026-42577 — netty-transport-native-epoll DoS via RST on half-closed TCP connection.
+# Advisory: https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p
+# This is a server-side bug — the GHSA description says the unclean shutdown affects
+# the "server-side channel" that has ALLOW_HALF_CLOSURE enabled. uid2-attestation-azure
+# is a JAR library that only makes outbound HTTPS calls (Azure attestation + Key Vault)
+# via the Azure SDK; it does not run a netty server or accept inbound connections.
+# Additionally, the netty maintainers only backported the fix to 4.2.13.Final and the
+# advisory's human-readable text states "All versions of 4.2.x" are affected — the OSV
+# structured range over-reports 4.1.x. We are on 4.1.133.Final. Tracking via UID2-7027.
+CVE-2026-42577 exp:2026-06-08

--- a/pom.xml
+++ b/pom.xml
@@ -42,21 +42,21 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Force netty to 4.1.132.Final to fix CVE-2026-33870 and CVE-2026-33871 (UID2-6916) -->
+            <!-- Force netty to 4.1.133.Final to fix CVE-2026-42583, CVE-2026-42579, CVE-2026-42584 (UID2-7027) -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.133.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.133.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary

Upgrades `io.netty` from 4.1.132.Final to 4.1.133.Final to fix three HIGH-severity CVEs disclosed on 2026-05-05:

| CVE | Module | Title |
|-----|--------|-------|
| CVE-2026-42583 | `netty-codec` | Lz4FrameDecoder resource exhaustion |
| CVE-2026-42579 | `netty-codec-dns` | DNS Codec input validation bypass |
| CVE-2026-42584 | `netty-codec-http` | HttpClientCodec response desynchronization |

All three are patched in 4.1.133.Final per Netty's GitHub security advisories.

A fourth CVE (CVE-2026-42577 — `netty-transport-native-epoll` epoll DoS) is reported by Trivy but per [GHSA-rwm7-x88c-3g2p](https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p), the vulnerable version range is `>= 4.2.0.Final, < 4.2.13.Final`. This repo is on the 4.1.x line and is not affected. If Trivy continues to report it after this upgrade, a follow-up commit will suppress it via `.trivyignore`.

netty is pulled in transitively by the Azure SDK; the repo does not use netty APIs directly.

Jira: https://thetradedesk.atlassian.net/browse/UID2-7027

## Test plan
- [ ] CI vulnerability-scan workflow passes (or only flags the known CVE-2026-42577 false positive)
- [ ] Build and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)