### PR TITLE
UID2-7278: upgrade Netty to 4.1.135.Final (CVE-2026-44249/45416/45674/47691)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,21 +42,21 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Force netty to 4.1.133.Final to fix CVE-2026-42583, CVE-2026-42579, CVE-2026-42584 (UID2-7027) -->
+            <!-- Force netty to 4.1.135.Final to fix CVE-2026-44249, CVE-2026-45416, CVE-2026-45674, CVE-2026-47691 (UID2-7278) -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary

Bumps all Netty module pins in `dependencyManagement` from `4.1.133.Final` → `4.1.135.Final` (netty-codec-http, netty-codec-http2, netty-bom). Fixes 4 HIGH CVEs:
- CVE-2026-44249 — netty-handler IPv6 filter bypass
- CVE-2026-45416 — netty-handler SNI DoS
- CVE-2026-45674 — netty-resolver-dns DNS cache poisoning
- CVE-2026-47691 — netty-resolver-dns NS bailiwick bypass

## Jira
[UID2-7278](https://thetradedesk.atlassian.net/browse/UID2-7278)

## Test plan
- [ ] CI vulnerability scan passes
- [ ] Unit tests pass