### PR TITLE
UID2-7027: .trivyignore cleanup — extend CVE-2026-42577 expiry to 2026-09-11

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -11,4 +11,4 @@
 # Additionally, the netty maintainers only backported the fix to 4.2.13.Final and the
 # advisory's human-readable text states "All versions of 4.2.x" are affected — the OSV
 # structured range over-reports 4.1.x. We are on 4.1.133.Final. Tracking via UID2-7027.
-CVE-2026-42577 exp:2026-06-08
+CVE-2026-42577 exp:2026-09-11


### PR DESCRIPTION
## Summary

Routine `.trivyignore` expiry cleanup — CVE-2026-42577 entry expired on 2026-06-08.

**CVE-2026-42577** (netty-transport-native-epoll DoS via RST on half-closed TCP, HIGH): Extended expiry from 2026-06-08 to **2026-09-11**, aligning with the rest of the UID2 service repos. Rationale:
- uid2-attestation-azure is a JAR library that only makes **outbound** HTTPS calls (Azure attestation + Key Vault via Azure SDK); it does not run a netty server or accept inbound connections
- This is even less exposed than the operator services
- No fix in netty 4.1.x; revisit on vert.x 5 migration (tracked via UID2-7027)

## Test plan

- [ ] Trivy vulnerability scan passes in CI
- [ ] No new CVEs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)