### PR TITLE
UID2-7364: Suppress jackson-databind CVEs + bump netty to 4.1.135.Final

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -12,3 +12,12 @@
 # advisory's human-readable text states "All versions of 4.2.x" are affected — the OSV
 # structured range over-reports 4.1.x. We are on 4.1.133.Final. Tracking via UID2-7027.
 CVE-2026-42577 exp:2026-06-08
+
+# jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
+# jackson-databind 2.18.4 is pulled in transitively via the Azure SDK (azure-core ->
+# azure-security-keyvault-secrets), not declared directly. No compatible fixed version is
+# available yet (current jackson 2.19.x does not contain the fix). Suppressing in the interim;
+# will be picked up via an Azure SDK bump once a fixed jackson ships in a compatible line.
+# See: UID2-7364
+CVE-2026-54512 exp:2026-07-25
+CVE-2026-54513 exp:2026-07-25

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,17 +2,6 @@
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/
 # for more details
 
-# CVE-2026-42577 — netty-transport-native-epoll DoS via RST on half-closed TCP connection.
-# Advisory: https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p
-# This is a server-side bug — the GHSA description says the unclean shutdown affects
-# the "server-side channel" that has ALLOW_HALF_CLOSURE enabled. uid2-attestation-azure
-# is a JAR library that only makes outbound HTTPS calls (Azure attestation + Key Vault)
-# via the Azure SDK; it does not run a netty server or accept inbound connections.
-# Additionally, the netty maintainers only backported the fix to 4.2.13.Final and the
-# advisory's human-readable text states "All versions of 4.2.x" are affected — the OSV
-# structured range over-reports 4.1.x. We are on 4.1.133.Final. Tracking via UID2-7027.
-CVE-2026-42577 exp:2026-06-08
-
 # jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
 # jackson-databind 2.18.4 is pulled in transitively via the Azure SDK (azure-core ->
 # azure-security-keyvault-secrets), not declared directly. No compatible fixed version is

--- a/pom.xml
+++ b/pom.xml
@@ -42,21 +42,22 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Force netty to 4.1.133.Final to fix CVE-2026-42583, CVE-2026-42579, CVE-2026-42584 (UID2-7027) -->
+            <!-- Force netty to 4.1.135.Final to fix CVE-2026-42583, CVE-2026-42579, CVE-2026-42584 (UID2-7027)
+                 and CVE-2026-44249, CVE-2026-45416, CVE-2026-50010, CVE-2026-45674, CVE-2026-47691 (UID2-7364) -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## UID2-7364: Suppress jackson-databind CVEs + bump netty to 4.1.135.Final

### jackson-databind (the reported scan failure)
The scheduled vulnerability scan flagged two HIGH CVEs in `com.fasterxml.jackson.core:jackson-databind` 2.18.4:

- **CVE-2026-54512** / **CVE-2026-54513** (HIGH) — general-purpose data-binding

jackson-databind is pulled in **transitively via the Azure SDK** (`azure-security-keyvault-secrets` → `azure-core`), not declared directly and not from uid2-shared. No fixed jackson version is available in a compatible line yet (upstream fix targets 2.18.8 / 2.21.4 / 3.1.4; current 2.19.x does not contain the fix). **Suppressed** both CVEs in `.trivyignore` (expiry **2026-07-25**), matching the approach approved in uid2-shared PR #631. The fix will be picked up via an Azure SDK bump once a fixed jackson ships.

### netty (surfaced by the inline PR scan)
The PR's inline Trivy scan surfaced **5 additional HIGH netty CVEs** in the existing `4.1.133.Final` pin:
- `netty-handler`: CVE-2026-44249, CVE-2026-45416, CVE-2026-50010
- `netty-resolver-dns`: CVE-2026-45674, CVE-2026-47691

All are fixed in **4.1.135.Final**. Bumped the existing `netty-bom` / `netty-codec-http(2)` pin from 4.1.133.Final → 4.1.135.Final (still covers the original UID2-7027 CVEs). Dependency tree verified: all netty artifacts resolve to 4.1.135.Final; compiles cleanly.

Tracked in UID2-7364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
