### PR TITLE
UID2-7557: suppress jackson-core GHSA-r7wm-3cxj-wff9 (async parser, not reachable)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -21,3 +21,9 @@ CVE-2026-42577 exp:2026-09-11
 # See: UID2-7364
 CVE-2026-54512 exp:2026-07-25
 CVE-2026-54513 exp:2026-07-25
+
+# jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
+# GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
+# jackson-core's non-blocking/async parser. A jackson bump is also in flight via uid2-shared
+# (PR #631) and will flow on the next release. See: UID2-7557 (predecessor UID2-6670)
+GHSA-r7wm-3cxj-wff9 exp:2026-08-23


### PR DESCRIPTION
## Vulnerability suppression — jackson-core GHSA-r7wm-3cxj-wff9 (HIGH)

Async-parser `maxNumberLength` bypass (incomplete fix for GHSA-72hv-8253-57qq). **Not reachable**: this service parses JSON only via the synchronous `ObjectMapper` API, never jackson-core’s non-blocking/async parser — the same rationale under which the predecessor advisory was suppressed (UID2-6670). A jackson bump is also in flight via uid2-shared PR #631 and will flow on the next release, at which point this can be removed.

Suppressed in `.trivyignore` with expiry **2026-08-23**. Ticket: UID2-7557.